### PR TITLE
Fix missing packages in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup
+from setuptools import setup, find_packages
 
 with open('README.rst') as file:
     content = file.read()
@@ -13,9 +13,7 @@ setup(
     author='Xavier Barbosa',
     author_email='clint.northwood@gmail.com',
     url='https://github.com/johnnoone/aioconsul',
-    packages=[
-        'aioconsul'
-    ],
+    packages=find_packages(),
     keywords=[
         'infrastructure',
         'asyncio',


### PR DESCRIPTION
Hello, I'm trying to use `aiohttp` app + `registrator` + `Consul` + `Consul-Template` + `nginx` into separate `Docker` containers. 
I install `aioconsul` from PyPI and tried to use it in my project but got an error in the import. I hope my patch could fix this problem.
